### PR TITLE
updated definition of CSR

### DIFF
--- a/Digital Identity/practical-implications-PKI.md
+++ b/Digital Identity/practical-implications-PKI.md
@@ -73,9 +73,10 @@ Terminology
     published by a Certificate Authority
 
 -   Certificate Signing Request (CSR): When requesting a certificate,
-    the requesting entity provides a copy of the private key along with
+    the requesting entity provides a copy of the public key along with
     their name and other information in a specially formatted binary
-    object called a CSR.
+    object called a CSR. The CSR must be signed using the requesting entity's
+    private key.
 
 -   Classical Computer: A computer that uses binary encoding and Boolean
     logic to make calculations in a deterministic way. Classical

--- a/terminology.md
+++ b/terminology.md
@@ -705,7 +705,7 @@ Heather Flanagan, editor - @ 2022 IDPro
 <td><a href="https://bok.idpro.org/article/id/80/">Practical Implications of Public Key Infrastructure for Identity Professionals</a></td>
 </tr>
 <tr class="odd">
-<td>Policy Access Point (PAP)</td>
+<td>Policy Administration Point (PAP)</td>
 <td>The location where the different types of owners define the access policy.</td>
 <td><a href="https://bok.idpro.org/article/id/42/">Introduction to Access Control</a></td>
 </tr>

--- a/terminology.md
+++ b/terminology.md
@@ -705,7 +705,7 @@ Heather Flanagan, editor - @ 2022 IDPro
 <td><a href="https://bok.idpro.org/article/id/80/">Practical Implications of Public Key Infrastructure for Identity Professionals</a></td>
 </tr>
 <tr class="odd">
-<td>Policy Administration Point (PAP)</td>
+<td>Policy Access Point (PAP)</td>
 <td>The location where the different types of owners define the access policy.</td>
 <td><a href="https://bok.idpro.org/article/id/42/">Introduction to Access Control</a></td>
 </tr>


### PR DESCRIPTION
According to the definition, a CSR contains a private key. Based on my experience, it includes a public key. The private key of the applicant is never shared with the registration authority.