### PR TITLE
Updated Terminology: fix term name of PAP

### DIFF
--- a/terminology.md
+++ b/terminology.md
@@ -705,7 +705,7 @@ Heather Flanagan, editor - @ 2022 IDPro
 <td><a href="https://bok.idpro.org/article/id/80/">Practical Implications of Public Key Infrastructure for Identity Professionals</a></td>
 </tr>
 <tr class="odd">
-<td>Policy Access Point (PAP)</td>
+<td>Policy Administration Point (PAP)</td>
 <td>The location where the different types of owners define the access policy.</td>
 <td><a href="https://bok.idpro.org/article/id/42/">Introduction to Access Control</a></td>
 </tr>


### PR DESCRIPTION
Corrected term "Policy Access Point" to "Policy Administration Point"