### PR TITLE
Suggested : Improve readability

### DIFF
--- a/Digital Identity/a-peek-into-the-future-of-decentralized-identity-final.md
+++ b/Digital Identity/a-peek-into-the-future-of-decentralized-identity-final.md
@@ -263,7 +263,7 @@ actors are as follows:
 
 -   Sam as the verifiable credential <u>subject</u> and <u>holder</u>.
 
--   A University as the verifiable credential <u>issuer</u>.
+-   Alice University as the verifiable credential <u>issuer</u>.
 
 -   Example Insurance as the verifiable credential <u>verifier</u>.
 


### PR DESCRIPTION
Using "A" as the name of a university reduces readability as it can be easily confused with the article "A". Consider changing to a word, for e.g. Alice University. This replacement needs to happen across other places in the article as well.